### PR TITLE
Setup Commands

### DIFF
--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -47,6 +47,6 @@ class Module(metaclass=ABCMeta):
         completed. Should return a List such that each item can be passed to the subprocess.run()
         function.
         """
-        return []
+        return ["sudo netfilter-persistent save", "sudo netfilter-persistent reload"]
     # end setup
 #end class Module

--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -1,14 +1,17 @@
 from pathlib import Path
 from typing_extensions import Self
+from abc import ABCMeta, abstractmethod
 
-class Module:
+class Module(metaclass=ABCMeta):
     """Base class all module should inherit from"""
+    @abstractmethod
     def generate(self: Self) -> str:
         """Generates the content of the configuration file."""
 
         raise NotImplementedError
     #end generate
 
+    @abstractmethod
     def install_location(self: Self) -> Path:
         """Returns the location that the config file should be installed to.
         This path should always be absolute. Relative paths will be assumed
@@ -38,4 +41,11 @@ class Module:
         except:
             return False
     #end validate
+
+    def setup_commands(self: Self) -> list[str] | list[list[str]]:
+        """Returns commands which are should be ran before the module's configuration output is completed.
+        Should return a list such that each item can be passed to the subprocess.run() function.
+        """
+        return []
+    # end setup
 #end class Module

--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from abc import ABCMeta, abstractmethod
-from typing_extensions import Self, Union
+from typing_extensions import Self, Union, List
 
 class Module(metaclass=ABCMeta):
     """Base class all module should inherit from"""
@@ -42,9 +42,9 @@ class Module(metaclass=ABCMeta):
             return False
     #end validate
 
-    def setup_commands(self: Self) -> Union[list[str], list[list[str]]]:
+    def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
         """Returns commands which are should be ran before the module's configuration output is
-        completed. Should return a list such that each item can be passed to the subprocess.run()
+        completed. Should return a List such that each item can be passed to the subprocess.run()
         function.
         """
         return []

--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from abc import ABCMeta, abstractmethod
-from typing_extensions import Self
+from typing_extensions import Self, Union
 
 class Module(metaclass=ABCMeta):
     """Base class all module should inherit from"""
@@ -42,7 +42,7 @@ class Module(metaclass=ABCMeta):
             return False
     #end validate
 
-    def setup_commands(self: Self) -> list[str] | list[list[str]]:
+    def setup_commands(self: Self) -> Union[list[str], list[list[str]]]:
         """Returns commands which are should be ran before the module's configuration output is
         completed. Should return a list such that each item can be passed to the subprocess.run()
         function.

--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from typing_extensions import Self
 from abc import ABCMeta, abstractmethod
+from typing_extensions import Self
 
 class Module(metaclass=ABCMeta):
     """Base class all module should inherit from"""
@@ -43,8 +43,9 @@ class Module(metaclass=ABCMeta):
     #end validate
 
     def setup_commands(self: Self) -> list[str] | list[list[str]]:
-        """Returns commands which are should be ran before the module's configuration output is completed.
-        Should return a list such that each item can be passed to the subprocess.run() function.
+        """Returns commands which are should be ran before the module's configuration output is
+        completed. Should return a list such that each item can be passed to the subprocess.run()
+        function.
         """
         return []
     # end setup

--- a/genisys/modules/base.py
+++ b/genisys/modules/base.py
@@ -47,6 +47,6 @@ class Module(metaclass=ABCMeta):
         completed. Should return a List such that each item can be passed to the subprocess.run()
         function.
         """
-        return ["sudo netfilter-persistent save", "sudo netfilter-persistent reload"]
+        return []
     # end setup
 #end class Module

--- a/genisys/modules/kernelparameter.py
+++ b/genisys/modules/kernelparameter.py
@@ -1,9 +1,6 @@
-from typing_extensions import Self
+from typing_extensions import Self, Union, List
 from pathlib import Path
-
 from genisys.modules import base
-from typing import Self
-from pathlib import Path
 
 class KernelParameter(base.module):
     ''' 99 prefix guarantees that this rule will overwrite sysctl.conf parameter assignment, this file will need to be created beforehand '''
@@ -22,6 +19,9 @@ class KernelParameter(base.module):
     def generate(self: Self) -> str:
         return "net.ipv4.ip_forward=1"
 
+
+    def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
+        return ["sysctl -p"]
     # end generate
 
     

--- a/genisys/modules/nat.py
+++ b/genisys/modules/nat.py
@@ -69,8 +69,8 @@ class Nat(base.Module):
 
     def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
 
-        return ["iptables-restore < " + self.IPV4_DIR, "netfilter-persistent reload", "systemctl enable iptables", "systemctl start iptables", "sysctl -p"]
+        return ["iptables-restore -f " + self.IPV4_DIR, "netfilter-persistent reload", "systemctl enable iptables", "systemctl start iptables"]
 
     # end setup_commands
-    
+
 # end nat class

--- a/genisys/modules/nat.py
+++ b/genisys/modules/nat.py
@@ -68,7 +68,8 @@ class Nat(base.Module):
     # end install_location
 
     def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
-        return ["sudo netfilter-persistent save", "sudo netfilter-persistent reload", "sudo systemctl enable iptables", "sudo systemctl start iptables"]
+
+        return ["iptables-restore < " + self.IPV4_DIR, "netfilter-persistent reload", "systemctl enable iptables", "systemctl start iptables", "sysctl -p"]
 
     # end setup_commands
     

--- a/genisys/modules/nat.py
+++ b/genisys/modules/nat.py
@@ -1,4 +1,4 @@
-from typing_extensions import Self
+from typing_extensions import Self, Union, List
 from pathlib import Path
 from genisys.modules import base
 from jinja2 import Template
@@ -67,4 +67,9 @@ class Nat(base.Module):
 
     # end install_location
 
+    def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
+        return ["sudo netfilter-persistent save", "sudo netfilter-persistent reload", "sudo systemctl enable iptables", "sudo systemctl start iptables"]
+
+    # end setup_commands
+    
 # end nat class

--- a/genisys/modules/netplan.py
+++ b/genisys/modules/netplan.py
@@ -65,7 +65,7 @@ class Netplan(Module):
         return yaml.dump(netplan)
     # end generate
 
-    def setup_commands(self: Self) -> list[str] | list[list[str]]:
+    def setup_commands(self: Self) -> Union[List[str], List[List[str]]]:
         return [ "netplan apply" ]
     # end setup_commands
 # end class Interface

--- a/genisys/modules/netplan.py
+++ b/genisys/modules/netplan.py
@@ -2,7 +2,7 @@ import ipaddress
 from pathlib import Path
 import yaml
 
-from typing_extensions import Self
+from typing_extensions import Self, Union, List
 from genisys.modules.base import Module
 
 NETPLAN_DIR = '/etc/netplan'

--- a/genisys/modules/netplan.py
+++ b/genisys/modules/netplan.py
@@ -64,4 +64,8 @@ class Netplan(Module):
         # return the yaml
         return yaml.dump(netplan)
     # end generate
+
+    def setup_commands(self: Self) -> list[str] | list[list[str]]:
+        return [ "netplan apply" ]
+    # end setup_commands
 # end class Interface


### PR DESCRIPTION
This PR adds a new function to the Module base class. The purpose of this function is to generate the executable and arguments that are needed to finish any setup for the module, ex. restart affected services. The function returns a list of commands that the calling function can then pass to the system to execute and/or display to the user. Ideally, the commands will be ran when the user calls `genisys install` and printed to the terminal (or possibly a file) when the user calls `genisys generate`. We may want to extend the command line specification to allow the user to prevent running these commands when installing.

This function does not need to be implemented for all subclasses. The default behavior is the return an empty list, which the calling function should then ignore.